### PR TITLE
Fix Chakra regex to grab latest version

### DIFF
--- a/engines/chakra/get-latest-version.js
+++ b/engines/chakra/get-latest-version.js
@@ -21,7 +21,7 @@ const getLatestVersion = () => {
 		try {
 			const response = await get(url);
 			// https://stackoverflow.com/a/1732454/96656
-			const regex = /<a href="\/Microsoft\/ChakraCore\/compare\/v(\d+\.\d+.\d+)\.\.\.master">/;
+			const regex = /href="\/Microsoft\/ChakraCore\/tree\/v(\d+\.\d+.\d+)"/;
 			const version = regex.exec(response.body)[1];
 			resolve(version);
 		} catch (error) {


### PR DESCRIPTION
fixes #31 

This grabs the version out of the first tagged release found: 
![image](https://user-images.githubusercontent.com/39191/38634706-332fa710-3d78-11e8-8b2c-f8823c9af934.png)
