### PR TITLE
Add instructions for use with eshost-cli on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,24 @@ npm install -g eshost-cli
 
 Then, tell eshost-cli where _jsvu_ installs each JavaScript engine:
 
+**Linux/Mac:**
+
 ```sh
 eshost --add 'Chakra' ch ~/.jsvu/chakra
 eshost --add 'JavaScriptCore' jsc ~/.jsvu/javascriptcore
 eshost --add 'SpiderMonkey' jsshell ~/.jsvu/spidermonkey
 eshost --add 'V8 --harmony' d8 ~/.jsvu/v8 --args '--harmony'
 eshost --add 'V8' d8 ~/.jsvu/v8
+```
+
+**Windows:**
+
+```bat
+eshost --add "Chakra" ch "%USERPROFILE%\.jsvu\chakra.cmd"
+eshost --add "JavaScriptCore" jsc "%USERPROFILE%\.jsvu\javascriptcore.cmd"
+eshost --add "SpiderMonkey" jsshell "%USERPROFILE%\.jsvu\spidermonkey.cmd"
+eshost --add "V8 --harmony" d8 "%USERPROFILE%\.jsvu\v8.cmd" --args "--harmony"
+eshost --add "V8" d8 "%USERPROFILE%\.jsvu\v8.cmd"
 ```
 
 That’s it! You can now run code snippets in all those engines with a single command:


### PR DESCRIPTION
Not sure how common this is anymore, but this should cover using jsvu/eshost-cli with `cmd`.