### PR TITLE
Get latest JavaScriptCore revision

### DIFF
--- a/engines/javascriptcore/get-latest-version.js
+++ b/engines/javascriptcore/get-latest-version.js
@@ -32,11 +32,16 @@ const getLatestVersion = (os) => {
 			});
 		}
 		case 'win32':
-		case 'win64':
+		case 'win64': {
+			return matchResponse({
+				url: 'https://build.webkit.org/builders/Apple%20Win%20Release%20%28Build%29?numbuilds=25',
+				regex: /<td><span[^>]+><a href="[^"]+">(\d+)<\/a><\/span><\/td>\s*<td class="success">success<\/td>/,
+			})
+		}
 		case 'mac64': {
 			return matchResponse({
-				url: 'https://nightly.webkit.org/',
-				regex: /<h6><a href="[^"]+">r(\d+)<\/a><\/h6>/,
+				url: 'https://build.webkit.org/builders/Apple%20High%20Sierra%20Release%20%28Build%29?numbuilds=25',
+				regex: /<td><span[^>]+><a href="[^"]+">(\d+)<\/a><\/span><\/td>\s*<td class="success">success<\/td>/,
 			});
 		}
 	}

--- a/engines/javascriptcore/predict-url.js
+++ b/engines/javascriptcore/predict-url.js
@@ -26,7 +26,7 @@ const predictUrl = (version, os) => {
 		}
 		case 'win32':
 		case 'win64': {
-			return `https://s3-us-west-2.amazonaws.com/archives.webkit.org/win-i386-debug/${version}.zip`;
+			return `https://s3-us-west-2.amazonaws.com/archives.webkit.org/win-i386-release/${version}.zip`;
 		}
 		default: {
 			throw new Error(


### PR DESCRIPTION
The pages on https://nightly.webkit.org/ are out of date. Although the
macOS builds still seem to be archived, the older Windows builds no
longer exist. Switch to looking for the most recent successful build
on the WebKit build status pages.

Also switched Windows to the release build.