### PR TITLE
respecting `--engines` without `--os` flag

### DIFF
--- a/shared/status.js
+++ b/shared/status.js
@@ -28,7 +28,7 @@ const getConfigFromFile = () => {
 	} catch (error) {
 		return {};
 	}
-}
+};
 
 const getStatus = () => {
 	const status = {};

--- a/shared/status.js
+++ b/shared/status.js
@@ -22,6 +22,14 @@ const jsvuPath = config.path;
 
 const statusFilePath = `${jsvuPath}/status.json`;
 
+const getConfigFromFile = () => {
+	try {
+		return require(statusFilePath);
+	} catch (error) {
+		return {};
+	}
+}
+
 const getStatus = () => {
 	const status = {};
 	const args = process.argv.slice(2);
@@ -41,11 +49,10 @@ const getStatus = () => {
 	if (status.os && status.engines) {
 		return status;
 	}
-	try {
-		return require(statusFilePath);
-	} catch (error) {
-		return {};
+	if (status.engines) {
+		return { ...getConfigFromFile(), engines: status.engines };
 	}
+	return getConfigFromFile();
 };
 
 const setStatus = (status) => {


### PR DESCRIPTION
- previously the `--engines` flag was only respected if the `--os` flag
  was provided as well
- now the provided `--engine` is merged with the existing config if
  it exists to provide the OS or prompts the user for it

FIXES: #37 

Sample output of current behavior:

```
/Volumes/d/dev/js/forks/jsvu
➝  ls ~/.jsvu

/Volumes/d/dev/js/forks/jsvu
➝  node ./cli.js --engines=v8
📦 jsvu v1.3.1 — the JavaScript engine Version Updater 📦
? What is your operating system? macOS 64-bit
✔ Read engines from config: v8
❯ Finding the latest V8 version…
^C

/Volumes/d/dev/js/forks/jsvu
➝  ls ~/.jsvu
status.json

/Volumes/d/dev/js/forks/jsvu
➝  node ./cli.js
📦 jsvu v1.3.1 — the JavaScript engine Version Updater 📦
✔ Read OS from config: mac64
✔ Read engines from config: v8
❯ Finding the latest V8 version…
^C

➝  node ./cli.js --os=arm64 --engines=v8
📦 jsvu v1.3.1 — the JavaScript engine Version Updater 📦
✔ Read OS from config: arm64
✔ Read engines from config: v8
❯ Finding the latest V8 version…
✖ Error: V8 does not offer precompiled arm64 binaries.
```

cc @mathiasbynens 