### PR TITLE
Avoid parsing GitHub’s HTML to determine Chakra version

### DIFF
--- a/engines/chakra/get-latest-version.js
+++ b/engines/chakra/get-latest-version.js
@@ -13,12 +13,19 @@
 
 'use strict';
 
-const matchResponse = require('../../shared/match-response.js');
+const get = require('../../shared/get.js');
 
-const getLatestVersion = () => {
-	return matchResponse({
-		url: 'https://github.com/Microsoft/ChakraCore/releases/latest',
-		regex: /href="\/Microsoft\/ChakraCore\/tree\/v(\d+\.\d+.\d+)"/,
+const getLatestVersion = (os) => {
+	const url = 'https://aka.ms/chakracore/version';
+	return new Promise(async (resolve, reject) => {
+		try {
+			const response = await get(url);
+			const body = response.body;
+			const version = body.trimEnd().replace(/_/g, '.');
+			resolve(version);
+		} catch (error) {
+			reject(error);
+		}
 	});
 };
 

--- a/engines/chakra/index.js
+++ b/engines/chakra/index.js
@@ -18,5 +18,5 @@ const updateEngine = require('../../shared/engine.js');
 module.exports = updateEngine({
 	name: 'Chakra',
 	id: 'chakra',
-	verifyChecksum: true,
+	verifyChecksum: false,
 });


### PR DESCRIPTION
The Chakra team now maintains a resource that responds with the latest available version number at <https://aka.ms/chakracore/version>.

https://github.com/Microsoft/ChakraCore/issues/5945#issuecomment-464027702