### PR TITLE
Remove "v" in V8-debug version

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ jsvu chakra@1.11.6
 jsvu javascriptcore@242640
 jsvu spidermonkey@66.0b13
 jsvu v8@7.2.502
-jsvu v8-debug@v7.1.302
+jsvu v8-debug@7.1.302
 jsvu xs@8.7.0
 ```
 


### PR DESCRIPTION
hi,

While i was trying to install the newest version of V8-debug by following the documentation i noticed an error in README.md (version was prefixed by "v" so the build was not found in my command line).

It might be wise to add an indication ? (or improving how the CLI handle the version).

Thanks for your work !

Best regards,
Thomas