### PR TITLE
Add --help command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -124,9 +124,8 @@ const promptEngines = () => {
 	const args = process.argv.slice(2);
 	for (const arg of args) {
 		if (arg === '--help' || arg === '-h') {
-			console.log('\nFor help on script usage and available arguments, please check the online documentation at:');
+			console.log('\nFor help on script usage and available arguments, please check the online documentation:');
 			console.log('https://github.com/GoogleChromeLabs/jsvu#readme');
-
 			return;
 		}
 		else if (arg.startsWith('--os=')) {

--- a/cli.js
+++ b/cli.js
@@ -123,7 +123,13 @@ const promptEngines = () => {
 
 	const args = process.argv.slice(2);
 	for (const arg of args) {
-		if (arg.startsWith('--os=')) {
+		if (arg.startsWith('--help') || arg.startsWith('-h')) {
+			console.log('\nFor help on script usage and available arguments, please check the online documentation at:');
+			console.log('https://github.com/GoogleChromeLabs/jsvu#readme');
+
+			return;
+		}
+		else if (arg.startsWith('--os=')) {
 			const os = arg.split('=')[1];
 			status.os = os;
 		}

--- a/cli.js
+++ b/cli.js
@@ -123,7 +123,7 @@ const promptEngines = () => {
 
 	const args = process.argv.slice(2);
 	for (const arg of args) {
-		if (arg.startsWith('--help') || arg.startsWith('-h')) {
+		if (arg === '--help' || arg === '-h') {
 			console.log('\nFor help on script usage and available arguments, please check the online documentation at:');
 			console.log('https://github.com/GoogleChromeLabs/jsvu#readme');
 


### PR DESCRIPTION
Add the help command (available with `--help` or `-h`).

Restricting to a simple message for the moment (with the link to the current project README). The link is simple (but it can be improved later with the terminal-link package).

Feel free to comment and ask updates (i can squash at the end).

Best Regards,
Thomas