### PR TITLE
Add an explicit default os option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ jsvu --os=linux64 --engines=all
 jsvu --os=linux64 --engines=chakra,hermes,javascriptcore,quickjs,spidermonkey,v8,xs
 ```
 
+If the operating system and architecture are not known in advance, the `--os=default` flag attempts to guess the correct value from the running environment. This might not be right for example if running a 32-bit Node.js process on a 64-bit machine.
+
 Note that `--engines=all` does not install the `v8-debug` binaries.
 
 ## Installing specific versions

--- a/cli.js
+++ b/cli.js
@@ -139,7 +139,7 @@ const promptEngines = () => {
 	for (const arg of args) {
 		if (arg.startsWith('--os=')) {
 			const os = arg.split('=')[1];
-			status.os = os;
+			status.os = os === 'default' ? guessOs() : os;
 		}
 		else if (arg.startsWith('--engines=')) {
 			const enginesArg = arg.split('=')[1];
@@ -159,7 +159,7 @@ const promptEngines = () => {
 				console.error('\nUnrecognized argument: ' + JSON.stringify(arg) + '\n');
 			}
 			console.log('[<engine>@<version>]');
-			console.log(`[--os={${ osChoices.map(choice => choice.value).join(',') }}]`);
+			console.log(`[--os={${ osChoices.map(choice => choice.value).join(',') },default}]`);
 			console.log(`[--engines={${ engineChoices.map(choice => choice.value).join(',') }},…]`);
 
 			console.log('\nComplete documentation is online:');


### PR DESCRIPTION
Uses the os guess from the default interactive prompt

Useful for running jsvu in npm scripts without knowing or detecting manually the environment.