### PR TITLE
Update Hermes package URL to point to hermes-engine

### DIFF
--- a/engines/hermes/get-latest-version.js
+++ b/engines/hermes/get-latest-version.js
@@ -16,7 +16,7 @@
 const get = require('../../shared/get.js');
 
 const getLatestVersion = (os) => {
-	const url = 'https://registry.npmjs.org/hermesvm';
+	const url = 'https://registry.npmjs.org/hermes-engine';
 	return new Promise(async (resolve, reject) => {
 		try {
 			const response = await get(url, {


### PR DESCRIPTION
jsvu was using the old Hermes npm package URL: `hermesvm`.
We changed this to `hermes-engine`: https://www.npmjs.com/package/hermes-engine