### PR TITLE
Update JSC URLs to support Mojave buildbots

### DIFF
--- a/engines/javascriptcore/get-latest-version.js
+++ b/engines/javascriptcore/get-latest-version.js
@@ -45,7 +45,7 @@ const getLatestVersion = (os) => {
 		}
 		case 'mac64': {
 			return matchResponse({
-				url: 'https://build.webkit.org/builders/Apple%20High%20Sierra%20Release%20%28Build%29?numbuilds=25',
+				url: 'https://build.webkit.org/builders/Apple%20Mojave%20Release%20%28Build%29?numbuilds=25',
 				regex: /<td><span[^>]+><a href="[^"]+">(\d+)<\/a><\/span><\/td>\s*<td class="success">success<\/td>/,
 			});
 		}

--- a/engines/javascriptcore/predict-url.js
+++ b/engines/javascriptcore/predict-url.js
@@ -16,7 +16,8 @@
 const predictUrl = (version, os) => {
 	switch (os) {
 		case 'mac64': {
-			return `https://s3-us-west-2.amazonaws.com/minified-archives.webkit.org/mac-highsierra-x86_64-release/${version}.zip`;
+			const macOsVersion = version > 254225 ? 'mojave' : 'highsierra';
+			return `https://s3-us-west-2.amazonaws.com/minified-archives.webkit.org/mac-${macOsVersion}-x86_64-release/${version}.zip`;
 		}
 		case 'linux32': {
 			return `https://webkitgtk.org/jsc-built-products/x86_32/release/${version}.zip`;


### PR DESCRIPTION
WebKit upgraded EWS bots to Mojave, so newer builds
built on Mojave only. 254224 is the latest available version
for High Sierra, use this build number to allow downloading an older
version of JSC.

Reference: https://bugs.webkit.org/show_bug.cgi?id=205948