### PR TITLE
Upgrade tempy

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"mkdirp": "^0.5.1",
 		"progress": "^2.0.3",
 		"tar": "^4.4.10",
-		"tempy": "^0.3.0",
+		"tempy": "^0.5.0",
 		"tildify": "^2.0.0",
 		"untildify": "^4.0.0",
 		"update-notifier": "^3.0.1"


### PR DESCRIPTION
Tempy 0.3.0 created files ending with a period https://github.com/sindresorhus/tempy/pull/19

On windows, this causes jsvu to emit errors in the Testing section of installing runtimes. The runtimes are still installed, but the console has warning messages.