### PR TITLE
Update URLs for GraalJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To update the installed JavaScript engines later on, just run `jsvu` again.
 - On 64-bit Windows, download the latest [WinCairoRequirements](https://github.com/WebKitForWindows/WinCairoRequirements/releases) and add its `bin64` directory to your `PATH`.
 
 [ch]: https://github.com/Microsoft/ChakraCore/issues/2278#issuecomment-277301120
-[graaljs]: https://github.com/graalvm/graaljs
+[graaljs]: https://github.com/oracle/graaljs
 [hermes]: https://github.com/facebook/hermes/issues/17
 [jsc]: https://bugs.webkit.org/show_bug.cgi?id=179945
 [quickjs]: https://github.com/GoogleChromeLabs/jsvu/issues/73

--- a/engines/graaljs/get-latest-version.js
+++ b/engines/graaljs/get-latest-version.js
@@ -16,11 +16,11 @@
 const get = require('../../shared/get.js');
 
 const getLatestVersion = () => {
-	const url = 'https://github.com/graalvm/graaljs/releases';
+	const url = 'https://github.com/oracle/graaljs/releases';
 	return new Promise(async (resolve, reject) => {
 		try {
 			const response = await get(url);
-			const regex = /href="\/graalvm\/graaljs\/releases\/tag\/vm-([^"]+)">Graal/;
+			const regex = /href="\/oracle\/graaljs\/releases\/tag\/vm-([^"]+)">Graal/;
 			const version = regex.exec(response.body)[1];
 			resolve(version);
 		} catch (error) {

--- a/engines/graaljs/predict-url.js
+++ b/engines/graaljs/predict-url.js
@@ -35,7 +35,7 @@ const predictFileName = (os) => {
 const predictUrl = (version, os) => {
 	const fileName = predictFileName(os);
 	const ext = os.startsWith('win') ? 'zip' : 'tar.gz';
-	const url = `https://github.com/graalvm/graaljs/releases/download/vm-${version}/graaljs-${version}-${fileName}-amd64.${ext}`;
+	const url = `https://github.com/oracle/graaljs/releases/download/vm-${version}/graaljs-${version}-${fileName}-amd64.${ext}`;
 	return url;
 };
 


### PR DESCRIPTION
I have changed `graalvm` to `oracle` in GraalJS URLs