### PR TITLE
Add support for mac64arm (M1 / Apple Silicone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To update the installed JavaScript engines later on, just run `jsvu` again.
 
 ## Supported engines per OS
 
-| JavaScript engine         | Binary name               | `mac64`            | `mac-arm64`     | `win32` | `win64`            | `linux32` | `linux64` |
+| JavaScript engine         | Binary name               | `mac64`            | `mac64arm`     | `win32` | `win64`            | `linux32` | `linux64` |
 | ------------------------- | ------------------------- | ------------------ | ----------- | ------- | ------------------ | --------- | --------- |
 | [**Chakra**][ch]          | `chakra` or `ch`          | ✅                  | ❌           | ✅      | ✅                 | ❌        | ✅        |
 | [**GraalJS**][graaljs]    | `graaljs`                 | ✅                  | ❌           | ❌      | ✅                 | ❌        | ✅        |

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ To update the installed JavaScript engines later on, just run `jsvu` again.
 
 ## Supported engines per OS
 
-| JavaScript engine         | Binary name               | `mac64`            | `win32` | `win64`            | `linux32` | `linux64` |
-| ------------------------- | ------------------------- | ------------------ | ------- | ------------------ | --------- | --------- |
-| [**Chakra**][ch]          | `chakra` or `ch`          | ✅                 | ✅      | ✅                 | ❌        | ✅        |
-| [**GraalJS**][graaljs]    | `graaljs`                 | ✅                 | ❌      | ✅                 | ❌        | ✅        |
-| [**Hermes**][hermes]      | `hermes` & `hermes-repl`  | ✅                 | ❌      | ✅                 | ❌        | ✅        |
-| [**JavaScriptCore**][jsc] | `javascriptcore` or `jsc` | ✅                 | ❌      | ✅ <sup>\*</sup>   | ❌        | ✅        |
-| [**QuickJS**][quickjs]    | `quickjs`                 | ❌                 | ✅      | ✅                 | ✅        | ✅        |
-| [**SpiderMonkey**][sm]    | `spidermonkey` or `sm`    | ✅                 | ✅      | ✅                 | ✅        | ✅        |
-| [**V8**][v8]              | `v8`                      | ✅                 | ✅      | ✅                 | ✅        | ✅        |
-| [**V8 debug**][v8]        | `v8-debug`                | ✅                 | ✅      | ✅                 | ✅        | ✅        |
-| [**XS**][xs]              | `xs`                      | ✅ <sup>(32)</sup> | ✅      | ✅ <sup>(32)</sup> | ✅        | ✅        |
+| JavaScript engine         | Binary name               | `mac64`            | `mac-arm64`     | `win32` | `win64`            | `linux32` | `linux64` |
+| ------------------------- | ------------------------- | ------------------ | ----------- | ------- | ------------------ | --------- | --------- |
+| [**Chakra**][ch]          | `chakra` or `ch`          | ✅                  | ❌           | ✅      | ✅                 | ❌        | ✅        |
+| [**GraalJS**][graaljs]    | `graaljs`                 | ✅                  | ❌           | ❌      | ✅                 | ❌        | ✅        |
+| [**Hermes**][hermes]      | `hermes` & `hermes-repl`  | ✅                  | ❌           | ❌      | ✅                 | ❌        | ✅        |
+| [**JavaScriptCore**][jsc] | `javascriptcore` or `jsc` | ✅                  | ❌           | ❌      | ✅ <sup>\*</sup>   | ❌        | ✅        |
+| [**QuickJS**][quickjs]    | `quickjs`                 | ❌                  | ❌           | ✅      | ✅                 | ✅        | ✅        |
+| [**SpiderMonkey**][sm]    | `spidermonkey` or `sm`    | ✅                  | ❌           | ✅      | ✅                 | ✅        | ✅        |
+| [**V8**][v8]              | `v8`                      | ✅                  | ✅           | ✅      | ✅                 | ✅        | ✅        |
+| [**V8 debug**][v8]        | `v8-debug`                | ✅                  | ✅           | ✅      | ✅                 | ✅        | ✅        |
+| [**XS**][xs]              | `xs`                      | ✅ <sup>(32)</sup>  | ❌           | ✅      | ✅ <sup>(32)</sup> | ✅        | ✅        |
 
 <sup>\*</sup> JavaScriptCore requires external dependencies to run on Windows:
 - On 32-bit Windows, install [iTunes](https://www.apple.com/itunes/download/).

--- a/cli.js
+++ b/cli.js
@@ -41,7 +41,7 @@ const getPlatform = () => {
 
 const osChoices = [
 	{ name: 'macOS 64-bit',    value: 'mac64'     },
-	{ name: 'macOS M1 64-bit', value: 'mac-arm64' },
+	{ name: 'macOS M1 64-bit', value: 'mac64arm' },
 	{ name: 'Linux 32-bit',     value: 'linux32'  },
 	{ name: 'Linux 64-bit',     value: 'linux64'  },
 	{ name: 'Windows 32-bit',   value: 'win32'    },
@@ -52,7 +52,7 @@ const guessOs = () => {
 	const platform = getPlatform();
 	if (platform === 'mac') {
 		if (os.arch() === 'arm64') {
-			return 'mac-arm64';
+			return 'mac64arm';
 		}
 		return 'mac64';
 	}

--- a/cli.js
+++ b/cli.js
@@ -40,8 +40,8 @@ const getPlatform = () => {
 };
 
 const osChoices = [
-	{ name: 'macOS 64-bit',    value: 'mac64'     },
-	{ name: 'macOS M1 64-bit', value: 'mac64arm' },
+	{ name: 'macOS 64-bit',     value: 'mac64'    },
+	{ name: 'macOS M1 64-bit',  value: 'mac64arm' },
 	{ name: 'Linux 32-bit',     value: 'linux32'  },
 	{ name: 'Linux 64-bit',     value: 'linux64'  },
 	{ name: 'Windows 32-bit',   value: 'win32'    },

--- a/cli.js
+++ b/cli.js
@@ -40,16 +40,20 @@ const getPlatform = () => {
 };
 
 const osChoices = [
-	{ name: 'macOS 64-bit',   value: 'mac64'   },
-	{ name: 'Linux 32-bit',   value: 'linux32' },
-	{ name: 'Linux 64-bit',   value: 'linux64' },
-	{ name: 'Windows 32-bit', value: 'win32'   },
-	{ name: 'Windows 64-bit', value: 'win64'   },
+	{ name: 'macOS 64-bit',    value: 'mac64'     },
+	{ name: 'macOS M1 64-bit', value: 'mac-arm64' },
+	{ name: 'Linux 32-bit',     value: 'linux32'  },
+	{ name: 'Linux 64-bit',     value: 'linux64'  },
+	{ name: 'Windows 32-bit',   value: 'win32'    },
+	{ name: 'Windows 64-bit',   value: 'win64'    },
 ];
 
 const guessOs = () => {
 	const platform = getPlatform();
 	if (platform === 'mac') {
+		if(os.arch() === 'arm64') {
+			return 'mac-arm64';
+		}
 		return 'mac64';
 	}
 	// Note: `os.arch()` returns the architecture of the Node.js process,

--- a/cli.js
+++ b/cli.js
@@ -51,7 +51,7 @@ const osChoices = [
 const guessOs = () => {
 	const platform = getPlatform();
 	if (platform === 'mac') {
-		if(os.arch() === 'arm64') {
+		if (os.arch() === 'arm64') {
 			return 'mac-arm64';
 		}
 		return 'mac64';

--- a/engines/v8-debug/extract.js
+++ b/engines/v8-debug/extract.js
@@ -33,6 +33,7 @@ const extract = ({ filePath, binary, os }) => {
 		const hasNativesBlob = installer.installLibrary('natives_blob.bin');
 		installer.installLibrary('snapshot_blob.bin');
 		switch (os) {
+			case 'mac64arm':
 			case 'mac64': {
 				installer.installLibraryGlob('*.dylib');
 				installer.installBinary({ 'd8': binary }, { symlink: false });

--- a/engines/v8-debug/extract.js
+++ b/engines/v8-debug/extract.js
@@ -33,8 +33,8 @@ const extract = ({ filePath, binary, os }) => {
 		const hasNativesBlob = installer.installLibrary('natives_blob.bin');
 		installer.installLibrary('snapshot_blob.bin');
 		switch (os) {
-			case 'mac64arm':
-			case 'mac64': {
+			case 'mac64':
+			case 'mac64arm': {
 				installer.installLibraryGlob('*.dylib');
 				installer.installBinary({ 'd8': binary }, { symlink: false });
 				installer.installScript({

--- a/engines/v8-debug/predict-file-name.js
+++ b/engines/v8-debug/predict-file-name.js
@@ -24,7 +24,7 @@ const predictFileName = (os) => {
 			return os;
 		default: {
 			throw new Error(
-				`V8-debug does not offer precompiled ${os} binaries.`
+				`V8 does not offer precompiled ${os} debug binaries.`
 			);
 		}
 	}

--- a/engines/v8-debug/predict-file-name.js
+++ b/engines/v8-debug/predict-file-name.js
@@ -15,24 +15,16 @@
 
 const predictFileName = (os) => {
 	switch (os) {
-		case 'mac64': {
-			return 'mac64';
-		}
-		case 'linux32': {
-			return 'linux32';
-		}
-		case 'linux64': {
-			return 'linux64';
-		}
-		case 'win32': {
-			return 'win32';
-		}
-		case 'win64': {
-			return 'win64';
-		}
+		case 'mac64':
+		case 'mac-arm64':
+		case 'linux32':
+		case 'linux64':
+		case 'win32':
+		case 'win64': 
+			return os;
 		default: {
 			throw new Error(
-				`V8 does not offer precompiled ${os} debug binaries.`
+				`V8-debug does not offer precompiled ${os} binaries.`
 			);
 		}
 	}

--- a/engines/v8-debug/predict-file-name.js
+++ b/engines/v8-debug/predict-file-name.js
@@ -15,13 +15,24 @@
 
 const predictFileName = (os) => {
 	switch (os) {
-		case 'mac64':
-		case 'mac-arm64':
-		case 'linux32':
-		case 'linux64':
-		case 'win32':
-		case 'win64': 
-			return os;
+		case 'mac64': {
+			return 'mac64';
+		}
+		case 'mac64arm': {
+			return 'mac-arm64';
+		}
+		case 'linux32': {
+			return 'linux32';
+		}
+		case 'linux64': {
+			return 'linux64';
+		}
+		case 'win32': {
+			return 'win32';
+		}
+		case 'win64': {
+			return 'win64';
+		}
 		default: {
 			throw new Error(
 				`V8 does not offer precompiled ${os} debug binaries.`

--- a/engines/v8/predict-file-name.js
+++ b/engines/v8/predict-file-name.js
@@ -15,21 +15,13 @@
 
 const predictFileName = (os) => {
 	switch (os) {
-		case 'mac64': {
-			return 'mac64';
-		}
-		case 'linux32': {
-			return 'linux32';
-		}
-		case 'linux64': {
-			return 'linux64';
-		}
-		case 'win32': {
-			return 'win32';
-		}
-		case 'win64': {
-			return 'win64';
-		}
+		case 'mac64':
+		case 'mac-arm64':
+		case 'linux32':
+		case 'linux64':
+		case 'win32':
+		case 'win64': 
+			return os;
 		default: {
 			throw new Error(
 				`V8 does not offer precompiled ${os} binaries.`

--- a/engines/v8/predict-file-name.js
+++ b/engines/v8/predict-file-name.js
@@ -15,13 +15,24 @@
 
 const predictFileName = (os) => {
 	switch (os) {
-		case 'mac64':
-		case 'mac-arm64':
-		case 'linux32':
-		case 'linux64':
-		case 'win32':
-		case 'win64': 
-			return os;
+		case 'mac64': {
+			return 'mac64';
+		}
+		case 'mac64arm': {
+			return 'mac-arm64';
+		}
+		case 'linux32': {
+			return 'linux32';
+		}
+		case 'linux64': {
+			return 'linux64';
+		}
+		case 'win32': {
+			return 'win32';
+		}
+		case 'win64': {
+			return 'win64';
+		}
 		default: {
 			throw new Error(
 				`V8 does not offer precompiled ${os} binaries.`


### PR DESCRIPTION
Closes #105 

The install for `v8-debug` fails for me, but it kinda _looks_ like it’s just a broken canary build rather than an error in the code? Can you confirm, @mathiasbynens? Also PTAL :D

<details>

<summary>Screenshot of the error when install <code>v8-debug</code></summary>

![Screenshot 2021-03-26 at 13 27 47](https://user-images.githubusercontent.com/234957/112638611-58420800-8e37-11eb-9b0c-1c34460814ee.png)


</details> 