### PR TITLE
Create an explicit `~/.jsvu/bin` path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Install the _jsvu_ CLI:
 npm install jsvu -g
 ```
 
-Modify your dotfiles (e.g. `~/.bashrc`) to add `~/.jsvu` to your `PATH`:
+Modify your dotfiles (e.g. `~/.bashrc`) to add `~/.jsvu/bin` to your `PATH`:
 
 ```sh
-export PATH="${HOME}/.jsvu:${PATH}"
+export PATH="${HOME}/.jsvu/bin:${PATH}"
 ```
 
 Then, run `jsvu`:
@@ -80,26 +80,26 @@ eshost --configure-jsvu
 ### Linux/Mac
 
 ```sh
-eshost --add 'Chakra' ch ~/.jsvu/chakra
-eshost --add 'GraalJS' graaljs ~/.jsvu/graaljs
-eshost --add 'JavaScriptCore' jsc ~/.jsvu/javascriptcore
-eshost --add 'QuickJS' qjs ~/.jsvu/quickjs
-eshost --add 'SpiderMonkey' jsshell ~/.jsvu/spidermonkey
-eshost --add 'V8 --harmony' d8 ~/.jsvu/v8 --args '--harmony'
-eshost --add 'V8' d8 ~/.jsvu/v8
-eshost --add 'XS' xs ~/.jsvu/xs
+eshost --add 'Chakra' ch ~/.jsvu/bin/chakra
+eshost --add 'GraalJS' graaljs ~/.jsvu/bin/graaljs
+eshost --add 'JavaScriptCore' jsc ~/.jsvu/bin/javascriptcore
+eshost --add 'QuickJS' qjs ~/.jsvu/bin/quickjs
+eshost --add 'SpiderMonkey' jsshell ~/.jsvu/bin/spidermonkey
+eshost --add 'V8 --harmony' d8 ~/.jsvu/bin/v8 --args '--harmony'
+eshost --add 'V8' d8 ~/.jsvu/bin/v8
+eshost --add 'XS' xs ~/.jsvu/bin/xs
 ```
 
 ### Windows
 
 ```bat
-eshost --add "Chakra" ch "%USERPROFILE%\.jsvu\chakra.cmd"
-eshost --add "GraalJS" graaljs "%USERPROFILE%\.jsvu\graaljs.cmd"
-eshost --add "JavaScriptCore" jsc "%USERPROFILE%\.jsvu\javascriptcore.cmd"
-eshost --add "SpiderMonkey" jsshell "%USERPROFILE%\.jsvu\spidermonkey.cmd"
-eshost --add "V8 --harmony" d8 "%USERPROFILE%\.jsvu\v8.cmd" --args "--harmony"
-eshost --add "V8" d8 "%USERPROFILE%\.jsvu\v8.cmd"
-eshost --add "XS" xs "%USERPROFILE%\.jsvu\xs.cmd"
+eshost --add "Chakra" ch "%USERPROFILE%\.jsvu\bin\chakra.cmd"
+eshost --add "GraalJS" graaljs "%USERPROFILE%\.jsvu\bin\graaljs.cmd"
+eshost --add "JavaScriptCore" jsc "%USERPROFILE%\.jsvu\bin\javascriptcore.cmd"
+eshost --add "SpiderMonkey" jsshell "%USERPROFILE%\.jsvu\bin\spidermonkey.cmd"
+eshost --add "V8 --harmony" d8 "%USERPROFILE%\.jsvu\bin\v8.cmd" --args "--harmony"
+eshost --add "V8" d8 "%USERPROFILE%\.jsvu\bin\v8.cmd"
+eshost --add "XS" xs "%USERPROFILE%\.jsvu\bin\xs.cmd"
 ```
 
 That’s it! You can now run code snippets in all those engines with a single command:
@@ -163,7 +163,7 @@ jsvu v8@7.2
 
 ## Security considerations
 
-_jsvu_ avoids the need for `sudo` privileges by installing everything in `~/.jsvu` rather than, say, `/usr/bin`.
+_jsvu_ avoids the need for `sudo` privileges by installing everything in `~/.jsvu/bin` rather than, say, `/usr/bin`.
 
 _jsvu_ downloads files over HTTPS, and only uses URLs that are controlled by the creators of the JavaScript engine or, in the case of JavaScriptCore on Linux, the port maintainers.
 

--- a/engines/chakra/test.js
+++ b/engines/chakra/test.js
@@ -19,16 +19,16 @@ const execa = require('execa');
 const tempy = require('tempy');
 
 const config = require('../../shared/config.js');
-const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const test = async ({ binary, alias }) => {
 	const path = tempy.file();
 	fs.writeFileSync(path, `print('Hi!');\n`);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, [path])).stdout === 'Hi!'
 	);
 	console.assert(
-		(await execa(`${jsvuPath}/${alias}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${alias}`, [path])).stdout === 'Hi!'
 	);
 };
 

--- a/engines/graaljs/test.js
+++ b/engines/graaljs/test.js
@@ -19,17 +19,17 @@ const execa = require('execa');
 const tempy = require('tempy');
 
 const config = require('../../shared/config.js');
-const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const test = async ({ binary }) => {
 	const path = tempy.file();
 	const program = `print('Hi!');\n`;
 	fs.writeFileSync(path, program);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, [path])).stdout === 'Hi!'
 	);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
 	);
 };
 

--- a/engines/hermes/test.js
+++ b/engines/hermes/test.js
@@ -19,16 +19,16 @@ const execa = require('execa');
 const tempy = require('tempy');
 
 const config = require('../../shared/config.js');
-const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const test = async ({ binary }) => {
 	const path = tempy.file();
 	const program = `print('Hi!');\n`;
 	fs.writeFileSync(path, program);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, [path])).stdout === 'Hi!'
 	);
-	const out = (await execa(`${jsvuPath}/${binary}`, ['-help'])).stdout;
+	const out = (await execa(`${jsvuBinPath}/${binary}`, ['-help'])).stdout;
 	console.assert(out.includes('Hermes driver'));
 	// TODO: Test hermes-repl <<< 'print("Hi!");', maybe?
 };

--- a/engines/javascriptcore/test.js
+++ b/engines/javascriptcore/test.js
@@ -19,17 +19,17 @@ const execa = require('execa');
 const tempy = require('tempy');
 
 const config = require('../../shared/config.js');
-const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const test = async ({ binary, alias }) => {
 	const path = tempy.file();
 	const program = `print('Hi!');\n`;
 	fs.writeFileSync(path, program);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, [path])).stdout === 'Hi!'
 	);
 	console.assert(
-		(await execa(`${jsvuPath}/${alias}`, ['-e', program])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${alias}`, ['-e', program])).stdout === 'Hi!'
 	);
 };
 

--- a/engines/quickjs/test.js
+++ b/engines/quickjs/test.js
@@ -19,17 +19,17 @@ const execa = require('execa');
 const tempy = require('tempy');
 
 const config = require('../../shared/config.js');
-const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const test = async ({ binary }) => {
 	const path = tempy.file();
 	const program = `print('Hi!');\n`;
 	fs.writeFileSync(path, program);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, [path])).stdout === 'Hi!'
 	);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
 	);
 };
 

--- a/engines/spidermonkey/test.js
+++ b/engines/spidermonkey/test.js
@@ -19,16 +19,16 @@ const execa = require('execa');
 const tempy = require('tempy');
 
 const config = require('../../shared/config.js');
-const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const test = async ({ binary, alias }) => {
 	const path = tempy.file();
 	fs.writeFileSync(path, `print('Hi!');\n`);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, [path])).stdout === 'Hi!'
 	);
 	console.assert(
-		(await execa(`${jsvuPath}/${alias}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${alias}`, [path])).stdout === 'Hi!'
 	);
 };
 

--- a/engines/v8-debug/test.js
+++ b/engines/v8-debug/test.js
@@ -19,17 +19,17 @@ const execa = require('execa');
 const tempy = require('tempy');
 
 const config = require('../../shared/config.js');
-const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const test = async ({ binary, alias }) => {
 	const path = tempy.file();
 	const program = `print('Hi!');\n`;
 	fs.writeFileSync(path, program);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, [path])).stdout === 'Hi!'
 	);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
 	);
 };
 

--- a/engines/v8/test.js
+++ b/engines/v8/test.js
@@ -19,17 +19,17 @@ const execa = require('execa');
 const tempy = require('tempy');
 
 const config = require('../../shared/config.js');
-const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const test = async ({ binary }) => {
 	const path = tempy.file();
 	const program = `print('Hi!');\n`;
 	fs.writeFileSync(path, program);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, [path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, [path])).stdout === 'Hi!'
 	);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
 	);
 };
 

--- a/engines/xs/test.js
+++ b/engines/xs/test.js
@@ -19,17 +19,17 @@ const execa = require('execa');
 const tempy = require('tempy');
 
 const config = require('../../shared/config.js');
-const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const test = async ({ binary }) => {
 	const path = tempy.file();
 	const program = `print('Hi!');\n`;
 	fs.writeFileSync(path, program);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, ['-s', path])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, ['-s', path])).stdout === 'Hi!'
 	);
 	console.assert(
-		(await execa(`${jsvuPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
+		(await execa(`${jsvuBinPath}/${binary}`, ['-e', program])).stdout === 'Hi!'
 	);
 };
 

--- a/shared/config.js
+++ b/shared/config.js
@@ -13,11 +13,10 @@
 
 'use strict';
 
-const os = require('os');
-
 const untildify = require('untildify');
 
 module.exports = {
 	path: untildify('~/.jsvu'),
+	binPath: untildify('~/.jsvu/bin'),
 	os: 'mac',
 };

--- a/shared/installer.js
+++ b/shared/installer.js
@@ -21,6 +21,7 @@ const tildify = require('tildify');
 
 const config = require('../shared/config.js');
 const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const installSingleBinary = (from, to) => {
 	console.log(`Installing binary to ${tildify(to)}…`);
@@ -78,7 +79,7 @@ class Installer {
 				);
 				if (options.symlink) {
 					installSingleBinarySymlink(
-						`${jsvuPath}/${to}`,
+						`${jsvuBinPath}/${to}`,
 						`${this.targetPath}/${to}`
 					);
 				}
@@ -91,7 +92,7 @@ class Installer {
 			);
 			if (options.symlink) {
 				installSingleBinarySymlink(
-					`${jsvuPath}/${from}`,
+					`${jsvuBinPath}/${from}`,
 					`${this.targetPath}/${from}`
 				);
 			}
@@ -102,14 +103,14 @@ class Installer {
 			for (const to of Object.keys(arg)) {
 				const from = arg[to];
 				installSingleBinarySymlink(
-					`${jsvuPath}/${from}`,
+					`${jsvuBinPath}/${from}`,
 					`${this.targetPath}/${to}`
 				);
 			}
 		} else {
 			const to = arg;
 			installSingleBinarySymlink(
-				`${jsvuPath}/${to}`,
+				`${jsvuBinPath}/${to}`,
 				`${this.targetPath}/${to}`
 			);
 		}
@@ -128,7 +129,7 @@ class Installer {
 		}
 	}
 	installScript({ name, alias, symlink, generateScript }) {
-		const to = `${jsvuPath}/${name}`;
+		const to = `${jsvuBinPath}/${name}`;
 		console.log(`Installing wrapper script to ${tildify(to)}…`);
 		const wrapperPath = process.platform === 'win32' ?
 			`%~dp0${this.targetRelPath}` :
@@ -141,9 +142,9 @@ class Installer {
 		fse.chmodSync(to, 0o555);
 		if (alias) {
 			if (symlink) {
-				installSingleBinarySymlink(`${jsvuPath}/${alias}`, to);
+				installSingleBinarySymlink(`${jsvuBinPath}/${alias}`, to);
 			} else {
-				fse.copySync(to, `${jsvuPath}/${alias}`);
+				fse.copySync(to, `${jsvuBinPath}/${alias}`);
 			}
 		}
 	}

--- a/shared/status.js
+++ b/shared/status.js
@@ -19,6 +19,7 @@ const mkdirp = require('mkdirp');
 
 const config = require('../shared/config.js');
 const jsvuPath = config.path;
+const jsvuBinPath = config.binPath;
 
 const statusFilePath = `${jsvuPath}/status.json`;
 
@@ -31,7 +32,7 @@ const getStatus = () => {
 };
 
 const setStatus = (status) => {
-	mkdirp.sync(jsvuPath);
+	mkdirp.sync(jsvuBinPath);
 	// Don’t store one-off CLI args in the persistent configuration.
 	const statusCopy = { ...status };
 	delete statusCopy.engine;


### PR DESCRIPTION
Previously, we asked users to add `~/.jsvu` to their `$PATH`, which meant that `status.json` and `engines` also became exposed (and autocompleted, etc.).

This patch moves the binaries and wrapper scripts to a dedicated `~/.jsvu/bin` directory containing nothing else.

This is a breaking change; jsvu users have to update their `$PATH` replacing `$HOME/.jsvu` with `$HOME/.jsvu/bin`.

Issue: #116