### PR TITLE
XS binaries moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To update the installed JavaScript engines later on, just run `jsvu` again.
 | [**SpiderMonkey**][sm]    | `spidermonkey` or `sm`    | ✅                  | ✅           | ✅      | ✅                 | ✅        | ✅        |
 | [**V8**][v8]              | `v8`                      | ✅                  | ✅           | ✅      | ✅                 | ✅        | ✅        |
 | [**V8 debug**][v8]        | `v8-debug`                | ✅                  | ✅           | ✅      | ✅                 | ✅        | ✅        |
-| [**XS**][xs]              | `xs`                      | ✅ <sup>(32)</sup>  | ❌           | ✅      | ✅ <sup>(32)</sup> | ✅        | ✅        |
+| [**XS**][xs]              | `xs`                      | ✅                  | ✅           | ❌      | ✅                 | ❌        | ✅        |
 
 <sup>\*</sup> JavaScriptCore requires external dependencies to run on Windows:
 - On 32-bit Windows, install [iTunes](https://www.apple.com/itunes/download/).

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ To update the installed JavaScript engines later on, just run `jsvu` again.
 
 ## Supported engines per OS
 
-| JavaScript engine         | Binary name               | `mac64`            | `mac64arm`     | `win32` | `win64`            | `linux32` | `linux64` |
-| ------------------------- | ------------------------- | ------------------ | ----------- | ------- | ------------------ | --------- | --------- |
-| [**Chakra**][ch]          | `chakra` or `ch`          | ✅                  | ❌           | ✅      | ✅                 | ❌        | ✅        |
-| [**GraalJS**][graaljs]    | `graaljs`                 | ✅                  | ❌           | ❌      | ✅                 | ❌        | ✅        |
-| [**Hermes**][hermes]      | `hermes` & `hermes-repl`  | ✅                  | ❌           | ❌      | ✅                 | ❌        | ✅        |
-| [**JavaScriptCore**][jsc] | `javascriptcore` or `jsc` | ✅                  | ✅           | ❌      | ✅ <sup>\*</sup>   | ❌        | ✅        |
-| [**QuickJS**][quickjs]    | `quickjs`                 | ❌                  | ❌           | ✅      | ✅                 | ✅        | ✅        |
-| [**SpiderMonkey**][sm]    | `spidermonkey` or `sm`    | ✅                  | ✅           | ✅      | ✅                 | ✅        | ✅        |
-| [**V8**][v8]              | `v8`                      | ✅                  | ✅           | ✅      | ✅                 | ✅        | ✅        |
-| [**V8 debug**][v8]        | `v8-debug`                | ✅                  | ✅           | ✅      | ✅                 | ✅        | ✅        |
-| [**XS**][xs]              | `xs`                      | ✅                  | ✅           | ❌      | ✅                 | ❌        | ✅        |
+| JavaScript engine         | Binary name               | `mac64` | `mac64arm` | `win32` | `win64`          | `linux32` | `linux64` |
+| ------------------------- | ------------------------- | ------- | ---------- | ------- | ---------------- | --------- | --------- |
+| [**Chakra**][ch]          | `chakra` or `ch`          | ✅      | ❌         | ✅      | ✅               | ❌        | ✅        |
+| [**GraalJS**][graaljs]    | `graaljs`                 | ✅      | ❌         | ❌      | ✅               | ❌        | ✅        |
+| [**Hermes**][hermes]      | `hermes` & `hermes-repl`  | ✅      | ❌         | ❌      | ✅               | ❌        | ✅        |
+| [**JavaScriptCore**][jsc] | `javascriptcore` or `jsc` | ✅      | ✅         | ❌      | ✅ <sup>\*</sup> | ❌        | ✅        |
+| [**QuickJS**][quickjs]    | `quickjs`                 | ❌      | ❌         | ✅      | ✅               | ✅        | ✅        |
+| [**SpiderMonkey**][sm]    | `spidermonkey` or `sm`    | ✅      | ✅         | ✅      | ✅               | ✅        | ✅        |
+| [**V8**][v8]              | `v8`                      | ✅      | ✅         | ✅      | ✅               | ✅        | ✅        |
+| [**V8 debug**][v8]        | `v8-debug`                | ✅      | ✅         | ✅      | ✅               | ✅        | ✅        |
+| [**XS**][xs]              | `xs`                      | ✅      | ✅         | ❌      | ✅               | ❌        | ✅        |
 
 <sup>\*</sup> JavaScriptCore requires external dependencies to run on Windows:
 - On 32-bit Windows, install [iTunes](https://www.apple.com/itunes/download/).

--- a/engines/xs/get-latest-version.js
+++ b/engines/xs/get-latest-version.js
@@ -16,12 +16,12 @@
 const get = require('../../shared/get.js');
 
 const getLatestVersion = async () => {
-	const url = 'https://api.github.com/repos/Moddable-OpenSource/moddable-xst/releases/latest';
+	const url = 'https://api.github.com/repos/Moddable-OpenSource/moddable/releases/latest';
 	const response = await get(url, {
 		json: true,
 	});
 	const data = response.body;
-	const version = data.tag_name.slice(1); // Strip `v` prefix.
+	const version = data.tag_name;
 	return version;
 };
 

--- a/engines/xs/predict-url.js
+++ b/engines/xs/predict-url.js
@@ -40,7 +40,7 @@ const predictFileName = (os) => {
 
 const predictUrl = (version, os) => {
 	const fileName = predictFileName(os);
-    const url = `https://github.com/Moddable-OpenSource/moddable/releases/download/${version}/xst-${fileName}.zip`;
+	const url = `https://github.com/Moddable-OpenSource/moddable/releases/download/${version}/xst-${fileName}.zip`;
 	return url;
 };
 

--- a/engines/xs/predict-url.js
+++ b/engines/xs/predict-url.js
@@ -16,19 +16,19 @@
 const predictFileName = (os) => {
 	switch (os) {
 		case 'mac64': {
-			return 'mac';
+			return 'mac64';
 		}
-		case 'linux32': {
-			return 'lin32';
+		case 'mac64arm':{
+			return 'mac64arm';
 		}
 		case 'linux64': {
 			return 'lin64';
 		}
-		case 'win32': {
-			return 'win';
+		case 'linux64arm': {
+			return 'lin64arm';
 		}
 		case 'win64': {
-			return 'win';
+			return 'win64';
 		}
 		default: {
 			throw new Error(
@@ -40,7 +40,7 @@ const predictFileName = (os) => {
 
 const predictUrl = (version, os) => {
 	const fileName = predictFileName(os);
-	const url = `https://github.com/Moddable-OpenSource/moddable-xst/releases/download/v${version}/xst-${fileName}.zip`;
+    const url = `https://github.com/Moddable-OpenSource/moddable/releases/download/${version}/xst-${fileName}.zip`;
 	return url;
 };
 

--- a/engines/xs/predict-url.js
+++ b/engines/xs/predict-url.js
@@ -21,6 +21,9 @@ const predictFileName = (os) => {
 		case 'mac64arm':{
 			return 'mac64arm';
 		}
+		case 'linux32': {
+			return 'lin32';
+		}
 		case 'linux64': {
 			return 'lin64';
 		}

--- a/engines/xs/predict-url.js
+++ b/engines/xs/predict-url.js
@@ -24,9 +24,6 @@ const predictFileName = (os) => {
 		case 'linux64': {
 			return 'lin64';
 		}
-		case 'linux64arm': {
-			return 'lin64arm';
-		}
 		case 'win64': {
 			return 'win64';
 		}


### PR DESCRIPTION
XS binaries moved to the main Moddable Open Source repo. 
The supported platforms are lin64, lin64arm, mac64, mac64arm and win64.
This commit updates the readme and related modules.
Thank you! 