### PR TITLE
Fix the JavaScriptCore download for MacOS

### DIFF
--- a/engines/javascriptcore/get-latest-version.js
+++ b/engines/javascriptcore/get-latest-version.js
@@ -15,6 +15,7 @@
 
 const get = require('../../shared/get.js');
 const matchResponse = require('../../shared/match-response.js');
+const getMacOsName = require('./get-macos-name.js');
 
 const hashToRevision = async (hash) => {
 	const revision = await matchResponse({
@@ -59,10 +60,20 @@ const getLatestVersion = (os) => {
 		}
 		case 'mac64':
 		case 'mac64arm': {
-			// Builder name: Apple-BigSur-Release-Build
-			// https://build.webkit.org/#/builders/29
-			// This publishes universal x86_64 + arm64 binaries.
-			return getLatestRevisionFromBuilder(29);
+			const name = getMacOsName();
+			if (name === 'ventura') {
+				// Builder name: Apple-Ventura-Release-Build
+				// https://build.webkit.org/#/builders/706
+				// This publishes universal x86_64 + arm64 binaries.
+				return getLatestRevisionFromBuilder(706);
+			} else if (name === 'monterey') {
+				// Builder name: Apple-Monterey-Release-Build
+				// https://build.webkit.org/#/builders/368
+				// This publishes universal x86_64 + arm64 binaries.
+				return getLatestRevisionFromBuilder(368);
+			} else {
+				throw new Error(`Unknown MacOS name: ${name}.`);
+			}
 		}
 		default: {
 			throw new Error(

--- a/engines/javascriptcore/get-macos-name.js
+++ b/engines/javascriptcore/get-macos-name.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { execSync } = require('node:child_process');
+
+const SEARCH_PATTERN = 'SOFTWARE LICENSE AGREEMENT FOR macOS';
+const LICENSE_FILE_PATH =
+	'/System/Library/CoreServices/Setup Assistant.app/Contents/Resources/en.lproj/OSXSoftwareLicense.rtf';
+
+const getMacOsName = () => {
+	const cmd = `awk '/${SEARCH_PATTERN}/' '${LICENSE_FILE_PATH}'`;
+	const stdout = execSync(cmd).toString();
+	let name = stdout.substring(stdout.indexOf(SEARCH_PATTERN) + SEARCH_PATTERN.length);
+	name = name.replace(/[^a-zA-Z]/g, '').toLowerCase();
+	return name;
+};
+
+module.exports = getMacOsName;

--- a/engines/javascriptcore/predict-url.js
+++ b/engines/javascriptcore/predict-url.js
@@ -13,11 +13,14 @@
 
 'use strict';
 
+const getMacOsName = require('./get-macos-name.js');
+
 const predictUrl = (version, os) => {
 	switch (os) {
 		case 'mac64':
 		case 'mac64arm': {
-			return `https://s3-us-west-2.amazonaws.com/minified-archives.webkit.org/mac-bigsur-x86_64%20arm64-release/${version}@main.zip`;
+			const name = getMacOsName();
+			return `https://s3-us-west-2.amazonaws.com/minified-archives.webkit.org/mac-${name}-x86_64%20arm64-release/${version}@main.zip`;
 		}
 		case 'linux64': {
 			return `https://webkitgtk.org/jsc-built-products/x86_64/release/${version}@main.zip`;


### PR DESCRIPTION
The old BigSur builder is no longer available. Updated to look for Ventura and Monterey instead.

Fixes #135.