### PR TITLE
Filter out unsuccessful builds while looking for the latest build of JSC

### DIFF
--- a/engines/javascriptcore/get-latest-version.js
+++ b/engines/javascriptcore/get-latest-version.js
@@ -27,7 +27,7 @@ const hashToRevision = async (hash) => {
 
 const getLatestCommitHashOrRevisionFromBuilder = async (builderId) => {
 	const url = `https://build.webkit.org/api/v2/builders/${builderId
-	}/builds?order=-number&limit=1&property=got_revision&complete=true`;
+	}/builds?order=-number&limit=1&property=got_revision&complete=true&results=0`;
 	const response = await get(url, {
 		json: true,
 	});


### PR DESCRIPTION
Honestly, I'm not 100% sure that it's the right way to do it, I just looked at the recent builds and noticed that fo success builds `results`  is 0, and for others, it is not 0.