### PR TITLE
Filter latest JSC revision to successful builds

### DIFF
--- a/engines/javascriptcore/get-latest-version.js
+++ b/engines/javascriptcore/get-latest-version.js
@@ -27,7 +27,7 @@ const hashToRevision = async (hash) => {
 
 const getLatestCommitHashOrRevisionFromBuilder = async (builderId) => {
 	const url = `https://build.webkit.org/api/v2/builders/${builderId
-	}/builds?order=-number&limit=1&property=got_revision&complete=true`;
+	}/builds?order=-number&limit=1&property=got_revision&complete=true&results=0`;
 	const response = await get(url, {
 		json: true,
 	});


### PR DESCRIPTION
Filter the JSC build query using `results=0` to limit the results to successful builds.