### PR TITLE
Support graal v23+ native standalone binary

### DIFF
--- a/engines/graaljs/extract.js
+++ b/engines/graaljs/extract.js
@@ -44,7 +44,10 @@ const extract = ({ filePath, binary, alias, os }) => {
 			case 'linux64': {
 				const directoryName = fs.readdirSync(tmpPath).find(file => file.startsWith('graaljs'));
 				const executableName = `${directoryName}/bin/js`;
-				installer.installBinary({ [executableName]: binary });
+				installer.installBinary(executableName, { symlink: false });
+				installer.installLibraryGlob(`${directoryName}/lib/*.so`)
+				installer.installLibraryGlob(`${directoryName}/modules/*.jar`)
+				installer.installBinarySymlink({ [executableName]: binary });
 				break;
 			}
 			case 'win64': {

--- a/engines/graaljs/extract.js
+++ b/engines/graaljs/extract.js
@@ -45,8 +45,8 @@ const extract = ({ filePath, binary, alias, os }) => {
 				const directoryName = fs.readdirSync(tmpPath).find(file => file.startsWith('graaljs'));
 				const executableName = `${directoryName}/bin/js`;
 				installer.installBinary(executableName, { symlink: false });
-				installer.installLibraryGlob(`${directoryName}/lib/*.so`)
-				installer.installLibraryGlob(`${directoryName}/modules/*.jar`)
+				installer.installLibraryGlob(`${directoryName}/lib/*.so`);
+				installer.installLibraryGlob(`${directoryName}/modules/*.jar`);
 				installer.installBinarySymlink({ [executableName]: binary });
 				break;
 			}

--- a/engines/graaljs/get-latest-version.js
+++ b/engines/graaljs/get-latest-version.js
@@ -21,7 +21,7 @@ const getLatestVersion = async () => {
 		json: true,
 	});
 	const data = response.body;
-	const version = data.tag_name.replace(/^(vm-|graal-)/,""); // Strip prefix.
+	const version = data.tag_name.replace(/^(vm-|graal-)/, ''); // Strip prefix.
 	return version;
 };
 

--- a/engines/graaljs/get-latest-version.js
+++ b/engines/graaljs/get-latest-version.js
@@ -21,7 +21,7 @@ const getLatestVersion = async () => {
 		json: true,
 	});
 	const data = response.body;
-	const version = data.tag_name.slice(3); // Strip `vm-` prefix.
+	const version = data.tag_name.replace(/^(vm-|graal-)/,""); // Strip prefix.
 	return version;
 };
 

--- a/engines/graaljs/predict-url.js
+++ b/engines/graaljs/predict-url.js
@@ -35,8 +35,8 @@ const predictFileName = (os) => {
 const predictUrl = (version, os) => {
 	const fileName = predictFileName(os);
 	const ext = os.startsWith('win') ? 'zip' : 'tar.gz';
-	const majorVersion = parseInt(version.split(".")[0]);
-	const prefix = majorVersion >= 23 ? "graal-" : "vm-";
+	const majorVersion = parseInt(version.split('.')[0]);
+	const prefix = majorVersion >= 23 ? 'graal-' : 'vm-';
 	const url = `https://github.com/oracle/graaljs/releases/download/${prefix}${version}/graaljs-${version}-${fileName}-amd64.${ext}`;
 	return url;
 };

--- a/engines/graaljs/predict-url.js
+++ b/engines/graaljs/predict-url.js
@@ -35,7 +35,9 @@ const predictFileName = (os) => {
 const predictUrl = (version, os) => {
 	const fileName = predictFileName(os);
 	const ext = os.startsWith('win') ? 'zip' : 'tar.gz';
-	const url = `https://github.com/oracle/graaljs/releases/download/vm-${version}/graaljs-${version}-${fileName}-amd64.${ext}`;
+	const majorVersion = parseInt(version.split(".")[0]);
+	const prefix = majorVersion >= 23 ? "graal-" : "vm-";
+	const url = `https://github.com/oracle/graaljs/releases/download/${prefix}${version}/graaljs-${version}-${fileName}-amd64.${ext}`;
 	return url;
 };
 


### PR DESCRIPTION
GraalJS from v23 onwards ships a standalone binary, with a slightly
different release path format, so support this.

Tested with both v22 and v24 (the latest as of writing).
