### PR TITLE
Support newer versions of hermes

### DIFF
--- a/engines/hermes/get-latest-version.js
+++ b/engines/hermes/get-latest-version.js
@@ -15,20 +15,14 @@
 
 const get = require('../../shared/get.js');
 
-const getLatestVersion = (os) => {
-	const url = 'https://registry.npmjs.org/hermes-engine';
-	return new Promise(async (resolve, reject) => {
-		try {
-			const response = await get(url, {
-				json: true,
-			});
-			const data = response.body;
-			const version = data['dist-tags'].latest;
-			resolve(version);
-		} catch (error) {
-			reject(error);
-		}
+const getLatestVersion = async (os) => {
+	const url = 'https://api.github.com/repos/facebook/hermes/releases/latest';
+	const response = await get(url, {
+		json: true,
 	});
+	const data = response.body;
+	const version = data.tag_name.replace(/^v/,""); // Strip prefix.
+	return version;
 };
 
 module.exports = getLatestVersion;

--- a/engines/hermes/get-latest-version.js
+++ b/engines/hermes/get-latest-version.js
@@ -21,7 +21,7 @@ const getLatestVersion = async (os) => {
 		json: true,
 	});
 	const data = response.body;
-	const version = data.tag_name.replace(/^v/,""); // Strip prefix.
+	const version = data.tag_name.replace(/^v/, ''); // Strip prefix.
 	return version;
 };
 

--- a/engines/hermes/predict-url.js
+++ b/engines/hermes/predict-url.js
@@ -35,9 +35,9 @@ const predictFileName = (os) => {
 
 const predictUrl = (version, os) => {
 	const fileName = predictFileName(os);
-	const majorVersion = parseInt(version.split(".")[0]);
-	const minorVersion = parseInt(version.split(".")[1]);
-	const suffix = majorVersion > 0 || minorVersion >= 13 ? "" : `-v${version}`;
+	const majorVersion = parseInt(version.split('.')[0]);
+	const minorVersion = parseInt(version.split('.')[1]);
+	const suffix = majorVersion > 0 || minorVersion >= 13 ? '' : `-v${version}`;
 	const url = `https://github.com/facebook/hermes/releases/download/v${version}/hermes-cli-${fileName}${suffix}.tar.gz`;
 	return url;
 };

--- a/engines/hermes/predict-url.js
+++ b/engines/hermes/predict-url.js
@@ -35,7 +35,10 @@ const predictFileName = (os) => {
 
 const predictUrl = (version, os) => {
 	const fileName = predictFileName(os);
-	const url = `https://github.com/facebook/hermes/releases/download/v${version}/hermes-cli-${fileName}-v${version}.tar.gz`;
+	const majorVersion = parseInt(version.split(".")[0]);
+	const minorVersion = parseInt(version.split(".")[1]);
+	const suffix = majorVersion > 0 || minorVersion >= 13 ? "" : `-v${version}`;
+	const url = `https://github.com/facebook/hermes/releases/download/v${version}/hermes-cli-${fileName}${suffix}.tar.gz`;
 	return url;
 };
 


### PR DESCRIPTION
The npm hermes-engine appears to be behind the actual hermes releases
(as of writing, stuck on v11 where v13 is available). Switch the hermes
downloader to look up the version via the github releases API, and fix
up the URL predictor to support a change in the download URL format.
