### PR TITLE
Update dependencies to fix npm vulnerability warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
 		"extract-zip": "^1.6.7",
 		"fs-extra": "^8.1.0",
 		"glob": "^7.1.4",
-		"got": "^9.6.0",
-		"inquirer": "^6.5.1",
+		"got": "^14.6.6",
+		"inquirer": "^13.2.0",
 		"mkdirp": "^0.5.1",
 		"progress": "^2.0.3",
-		"tar": "^4.4.10",
+		"tar": "^7.5.2",
 		"tempy": "^0.5.0",
 		"tildify": "^2.0.0",
 		"untildify": "^4.0.0",
-		"update-notifier": "^3.0.1"
+		"update-notifier": "^7.3.1"
 	}
 }


### PR DESCRIPTION
...by running `npm audit fix --force` which bumped several major versions.

Before we got several warnings:
```
~/jsvu$ npm audit
# npm audit report

cross-spawn  <6.0.6
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix --force`
Will install update-notifier@7.3.1, which is a breaking change
node_modules/term-size/node_modules/cross-spawn
  execa  0.5.0 - 0.9.0
  Depends on vulnerable versions of cross-spawn
  node_modules/term-size/node_modules/execa
    term-size  1.0.0 - 1.2.0
    Depends on vulnerable versions of execa
    node_modules/term-size
      boxen  1.2.0 - 3.2.0
      Depends on vulnerable versions of term-size
      node_modules/boxen
        update-notifier  0.2.0 - 5.1.0
        Depends on vulnerable versions of boxen
        Depends on vulnerable versions of latest-version
        node_modules/update-notifier

got  <11.8.5
Severity: moderate
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
fix available via `npm audit fix --force`
Will install got@14.6.6, which is a breaking change
node_modules/got
  package-json  <=6.5.0
  Depends on vulnerable versions of got
  node_modules/package-json
    latest-version  0.2.0 - 5.1.0
    Depends on vulnerable versions of package-json
    node_modules/latest-version

tar  <6.2.1
Severity: moderate
Denial of service while parsing a tar file due to lack of folders count validation - https://github.com/advisories/GHSA-f5x3-32g6-xq36
fix available via `npm audit fix --force`
Will install tar@7.5.2, which is a breaking change
node_modules/tar

tmp  <=0.2.3
tmp allows arbitrary temporary file / directory write via symbolic link `dir` parameter - https://github.com/advisories/GHSA-52f5-9888-hmc6
fix available via `npm audit fix --force`
Will install inquirer@13.2.0, which is a breaking change
node_modules/tmp
  external-editor  >=1.1.1
  Depends on vulnerable versions of tmp
  node_modules/external-editor
    inquirer  3.0.0 - 8.2.6 || 9.0.0 - 9.3.7
    Depends on vulnerable versions of external-editor
    node_modules/inquirer

12 vulnerabilities (3 low, 4 moderate, 5 high)

To address all issues (including breaking changes), run:
  npm audit fix --force
```